### PR TITLE
Sets livepeer social to be a hashtag feed

### DIFF
--- a/widget/page/social.jsx
+++ b/widget/page/social.jsx
@@ -11,22 +11,11 @@ const Grid = styled.div`
 
 return (
   <Feed
+    showCompose={true}
     index={[
       {
-        action: "post",
-        key: "main",
-        options: {
-          limit: 10,
-          order: "desc",
-          accountId: props.accounts,
-        },
-        cacheOptions: {
-          ignoreCache: true,
-        },
-      },
-      {
-        action: "repost",
-        key: "main",
+        action: "hashtag",
+        key: "livepeer",
         options: {
           limit: 10,
           order: "desc",


### PR DESCRIPTION
Tracks posts with #livepeer, and will automatically append and index posts with this hashtag